### PR TITLE
Add support for identity, the "i=" tag

### DIFF
--- a/lib/dkim.rb
+++ b/lib/dkim.rb
@@ -25,6 +25,7 @@ end
 
 Dkim::signable_headers        = Dkim::DefaultHeaders.dup
 Dkim::domain                  = nil
+Dkim::identity                = nil
 Dkim::selector                = nil
 Dkim::signing_algorithm       = 'rsa-sha256'
 Dkim::private_key             = nil

--- a/lib/dkim/options.rb
+++ b/lib/dkim/options.rb
@@ -40,6 +40,12 @@ module Dkim
     define_option_method :domain
 
     # @attribute [rw]
+    # The identity used for signing.
+    # This corresponds to the i= tag in the dkim header.
+    # @return [String] identity
+    define_option_method :identity
+
+    # @attribute [rw]
     # Selector used for signing.
     # This corresponds to the s= tag in the dkim header.
     # @return [String] selector

--- a/lib/dkim/signed_mail.rb
+++ b/lib/dkim/signed_mail.rb
@@ -59,6 +59,7 @@ module Dkim
       dkim_header['a'] = signing_algorithm
       dkim_header['c'] = "#{header_canonicalization}/#{body_canonicalization}"
       dkim_header['d'] = domain
+      dkim_header['i'] = identity if identity
       dkim_header['q'] = 'dns/txt'
       dkim_header['s'] = selector
       dkim_header['t'] = (time || Time.now).to_i

--- a/test/dkim/interceptor_test.rb
+++ b/test/dkim/interceptor_test.rb
@@ -56,6 +56,7 @@ Joe.
       Dkim.header_canonicalization = 'relaxed'
       Dkim.body_canonicalization = 'relaxed'
       Dkim.signing_algorithm = 'rsa-sha256'
+      Dkim.identity = '@example.com'
       Interceptor.delivering_email(@mail)
       dkim_header = @mail['DKIM-Signature']
 
@@ -63,6 +64,7 @@ Joe.
       assert_includes dkim_header.to_s, 'rsa-sha256'
       assert_includes dkim_header.to_s, 's=brisbane'
       assert_includes dkim_header.to_s, 'd=example.com'
+      assert_includes dkim_header.to_s, 'i=@example.com'
       assert_includes dkim_header.to_s, 'c=relaxed/relaxed'
       assert_includes dkim_header.to_s, 'q=dns/txt'
       assert_includes dkim_header.to_s, 'bh=2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8='
@@ -74,12 +76,14 @@ Joe.
       Dkim.header_canonicalization = 'simple'
       Dkim.body_canonicalization = 'simple'
       Dkim.signing_algorithm = 'rsa-sha256'
+      Dkim.identity = '@example.com'
       Interceptor.delivering_email(@mail)
       dkim_header = @mail['DKIM-Signature']
       assert dkim_header
       assert_includes dkim_header.to_s, 'rsa-sha256'
       assert_includes dkim_header.to_s, 's=brisbane'
       assert_includes dkim_header.to_s, 'd=example.com'
+      assert_includes dkim_header.to_s, 'i=@example.com'
       assert_includes dkim_header.to_s, 'c=simple/simple'
       assert_includes dkim_header.to_s, 'q=dns/txt'
       assert_includes dkim_header.to_s, 'bh=2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8='

--- a/test/dkim/options_test.rb
+++ b/test/dkim/options_test.rb
@@ -19,6 +19,7 @@ module Dkim
         :signing_algorithm => 'abc123',
         :signable_headers => [],
         :domain => 'example.net',
+        :identity => '@example.net',
         :selector => 'selector',
         :time => 'time',
         :header_canonicalization => 'simple',

--- a/test/dkim/signed_mail_test.rb
+++ b/test/dkim/signed_mail_test.rb
@@ -46,6 +46,21 @@ module Dkim
       assert_equal 't+dk4yxTI2ByZxxRzkwhZhM4WzTZjGWHiWnS2t4pg7oT7fAIlMrfihJ/CIvGmYqYv4lbq4LStHqHx9TmEgxrkjLevHtuqhxkN55xJ2vA2QzTzFi2fMDZ4fFqWy4QtvlLjBAhevG+LXpmjPYec1cyeMlHlPAthq5+RNi6NHErJiM=', dkim_header['b']
     end
 
+    def test_identity
+      options = {
+        :domain => 'example.org',
+        :selector => 'sidney',
+        :identity => '@example.org',
+        :time => Time.at(1234567890)
+      }
+      signed_mail = SignedMail.new(@mail, options)
+      dkim_header = signed_mail.dkim_header.list
+
+      assert_equal '@example.org',                                  dkim_header['i']
+      assert_equal '2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8=',  dkim_header['bh']
+      assert_equal 'dCiulbJTD+GCCItMij1IU/RO0+q73afdjmrCWV5Qu7BIT5Kbp5Oi3jqCzj/v8Juks2/L6GBSXZia3aZprNVZX0szt8RnwC9NJx9WhcjN2RPz4Zf5F1jJivCN+PtaIWA3i3Ki/DR1q+RuNPgs7T1KKMo3Ih5uHubZIsMwRzbQBc0=', dkim_header['b']
+    end
+
     def test_empty_body_hashes
       @mail = @mail.split("\n\n").first + "\n\n"
 


### PR DESCRIPTION
Hi. Thanks for developing this gem.

I've seen that some mail servers are not interpreting a missing i= tag as the default value @d (as per RFC 6376#3.5), so I needed a way of setting it. Maybe you can use it in the gem.
- Kristoffer
