### PR TITLE
Changed interceptor to append a Mail::Field instead of a Mail::DkimField...

### DIFF
--- a/lib/dkim/interceptor.rb
+++ b/lib/dkim/interceptor.rb
@@ -3,6 +3,7 @@ module Dkim
   class Interceptor
     def self.delivering_email(message)
       require 'mail/dkim_field'
+      require 'mail/register_dkim_field'
 
       # strip any existing signatures
       if message['DKIM-Signature']
@@ -15,7 +16,7 @@ module Dkim
       dkim_signature = SignedMail.new(message.encoded).dkim_header.value
 
       # prepend signature to message
-      message.header.fields.unshift Mail::DkimField.new(dkim_signature)
+      message.header.fields << Mail::Field.new(Mail::DkimField::CAPITALIZED_FIELD, dkim_signature)
       message
     end
   end

--- a/lib/mail/register_dkim_field.rb
+++ b/lib/mail/register_dkim_field.rb
@@ -1,0 +1,9 @@
+require 'mail/dkim_field'
+
+unless Mail::Field::FIELDS_MAP.has_key?(Mail::DkimField::FIELD_NAME)
+  Mail::Field::FIELDS_MAP[Mail::DkimField::FIELD_NAME] = Mail::DkimField
+  Mail::Field::STRUCTURED_FIELDS << Mail::DkimField::FIELD_NAME
+  if defined?(Mail::Field::FIELD_ORDER_LOOKUP)
+    Mail::Field::FIELD_ORDER_LOOKUP[Mail::DkimField::FIELD_NAME] = 8
+  end
+end

--- a/test/dkim/interceptor_test.rb
+++ b/test/dkim/interceptor_test.rb
@@ -124,6 +124,18 @@ Joe.
 
       assert_equal expected, @mail.to_s
     end
+    
+    def test_dkim_header_is_a_dkim_field
+      dkim_header = @mail['DKIM-Signature']
+
+      # Most necessary under simple
+      Dkim.header_canonicalization = 'simple'
+      Dkim.body_canonicalization = 'simple'
+
+      Interceptor.delivering_email(@mail)
+      
+      assert @mail['DKIM-Signature'].field.is_a?(Mail::DkimField)
+    end
   end
 end
 


### PR DESCRIPTION
Resolving issue https://github.com/jhawthorn/dkim/issues/8

Registered DkimField with Mail so field header class is not an OptionField.

This does fail test `Dkim::InterceptorTest#test_same_output_as_direct_usage` with Mail 2.5.3 as field order works differently.
