### PR TITLE
Fix Rubinius string in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
   - 2.0.0
   - 2.1.0
   - jruby-19mode
-  - rbx
+  - rbx-2


### PR DESCRIPTION
This gets the Rubinius build running in Travis.  The build is still failing, apparently because of an issue in the Rubinius mail gem.