### PR TITLE
Replace MiniTest::Unit::TestCase with Minitest::Test

### DIFF
--- a/test/dkim/canonicalization_test.rb
+++ b/test/dkim/canonicalization_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 module Dkim
-  class CanonicalizationTest < MiniTest::Unit::TestCase
+  class CanonicalizationTest < Minitest::Test
     # from section 3.4.6 of RFC 6376
     def setup
       @input = <<-eos.rfc_format

--- a/test/dkim/canonicalized_headers_test.rb
+++ b/test/dkim/canonicalized_headers_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 module Dkim
-  class CanonicalizedHeadersTest < MiniTest::Unit::TestCase
+  class CanonicalizedHeadersTest < Minitest::Test
     def test_maintains_order
       headers = "ABCD".chars.map {|c| Header.new(c, c) }
       header_keys = headers.map &:relaxed_key

--- a/test/dkim/dkim_header_test.rb
+++ b/test/dkim/dkim_header_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 require 'base64'
 
 module Dkim
-  class DkimHeaderTest < MiniTest::Unit::TestCase
+  class DkimHeaderTest < Minitest::Test
     def setup
       @header = DkimHeader.new
 

--- a/test/dkim/encodings_test.rb
+++ b/test/dkim/encodings_test.rb
@@ -1,5 +1,5 @@
 module Dkim
-  class EncodingsTest < MiniTest::Unit::TestCase
+  class EncodingsTest < Minitest::Test
     def test_plain_text
       @encoder = Encodings::PlainText.new
       assert_equal 'testing123', @encoder.encode('testing123')

--- a/test/dkim/interceptor_test.rb
+++ b/test/dkim/interceptor_test.rb
@@ -36,7 +36,7 @@ We lost the game. Are you hungry yet?
 Joe.
   eos
 
-  class InterceptorTest < MiniTest::Unit::TestCase
+  class InterceptorTest < Minitest::Test
     def setup
       @original_options = Dkim.options.dup
 

--- a/test/dkim/options_test.rb
+++ b/test/dkim/options_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Dkim
-  class OptionsTest < MiniTest::Unit::TestCase
+  class OptionsTest < Minitest::Test
     def setup
       klass = Class.new
       klass.send :include, Options

--- a/test/dkim/signed_mail_test.rb
+++ b/test/dkim/signed_mail_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 module Dkim
-  class SignedMailTest < MiniTest::Unit::TestCase
+  class SignedMailTest < Minitest::Test
     def setup
       @mail = EXAMPLEEMAIL.dup
     end

--- a/test/dkim/tag_value_list_test.rb
+++ b/test/dkim/tag_value_list_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 module Dkim
-  class TagValueListTest < MiniTest::Unit::TestCase
+  class TagValueListTest < Minitest::Test
     def test_replacement
       @list = TagValueList.new
 


### PR DESCRIPTION
Eliminate deprecated class warnings by updating class name.
