### PR TITLE
Wrap DKIM headers at 79 characters

### DIFF
--- a/lib/dkim/dkim_header.rb
+++ b/lib/dkim/dkim_header.rb
@@ -11,7 +11,7 @@ module Dkim
       @list = TagValueList.new values
     end
     def value
-      " #{@list}"
+      wrap " #{@list}", key.size + 2
     end
     def [] k
       encoder_for(k).decode(@list[k])
@@ -32,6 +32,55 @@ module Dkim
       else
         raise "unknown key: #{key}"
       end.new
+    end
+
+    def wrap(raw, prepend=0) # :nodoc:
+      words = raw.split(/[ \t]/)
+      custom_split_words = []
+      words.each do |word|
+        if word.start_with?('h=')
+          # header field list can be folded at ":"
+          custom_split_words.concat(word.split(/(?<=:)/))
+        elsif word.start_with?('b=') || word.start_with?('bh=')
+          # base64 encoded fields can be folded anywhere. Use fixed
+          # length substrings
+          offset = 0
+          len = 60
+          until word[offset].nil?
+            custom_split_words <<= word[offset, len]
+            offset += len
+          end
+        else
+          custom_split_words <<= word
+        end
+      end
+
+      # Simplified ASCII-only version of wrap from Fields::UnstructuredField
+      folded_lines = []
+      until custom_split_words.empty?
+        limit = 78 - prepend
+        line = String.new
+        first_word = true
+        until custom_split_words.empty?
+          break unless word = custom_split_words.first.dup
+          break if !line.empty? && (line.length + word.length + 1 > limit)
+
+          # Remove the word from the queue ...
+          custom_split_words.shift
+          # Add word separator
+          if first_word
+            first_word = false
+          else
+            line << ' '
+          end
+          # ... add it in encoded form to the current line
+          line << word
+        end
+        # Add the line to the output and reset the prepend
+        folded_lines << line
+        prepend = 0
+      end
+      folded_lines.join("\r\n    ")
     end
   end
 end

--- a/test/dkim/signed_mail_test.rb
+++ b/test/dkim/signed_mail_test.rb
@@ -20,7 +20,7 @@ module Dkim
 
       # bh value from RFC 6376
       assert_equal '2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8=', dkim_header['bh']
-      assert_equal 'dQOeSpGJTfSbX4hPGGsy4ipcNAzC/33K7XaEXkjBneJJhv6MczHkJNsfmXeYESNIh5WVTuvE5IbnDPBVFrL+b3GKiLiyp/vlKO2NJViX4dLnKT/GdxjJh06ljZcYjUA+PorHvMwdu+cDsCffN8A7IhfVdsFruQr3vFPD0JyJ9XU=', dkim_header['b']
+      assert_equal 'QppIlbEcMAX4axIDBcTDYmr5UMS+qZygn6pcHzxw5glhBU0rDMy2bAPN1SqaQnx8pnpbaVtvS5YpkzYf5HOSARRZKerKat1XiN1MHrZzSL7gBUdDU++uGVcqq/CS8sEfUKBQtbAdWychFUx0EkPZrDJdYQZy/UEd+mx1UY4GNY4=', dkim_header['b']
     end
 
     def test_overrides
@@ -43,7 +43,7 @@ module Dkim
       assert_equal 'dns/txt',                         dkim_header['q']
       assert_equal "from:to:subject:date:message-id", dkim_header['h']
       assert_equal 'yk6W9pJJilr5MMgeEdSd7J3IaJI=',    dkim_header['bh']
-      assert_equal 't+dk4yxTI2ByZxxRzkwhZhM4WzTZjGWHiWnS2t4pg7oT7fAIlMrfihJ/CIvGmYqYv4lbq4LStHqHx9TmEgxrkjLevHtuqhxkN55xJ2vA2QzTzFi2fMDZ4fFqWy4QtvlLjBAhevG+LXpmjPYec1cyeMlHlPAthq5+RNi6NHErJiM=', dkim_header['b']
+      assert_equal 'iDzlYPN071tQNcjQHle367n+1ZxnipOr5J3GPj/SUrKgDUXqF7r65Uf23FZMMibYgC3uXZgRFgXrRObBfccJpCgEqp/B8P/mI4jGc3EMuVLUiMrx79beZQOe7a0vSJNwBsqu7fkz1UWp5o2DXT8anUNixV41+37aRakAB5ChYSU=', dkim_header['b']
     end
 
     def test_identity
@@ -58,7 +58,7 @@ module Dkim
 
       assert_equal '@example.org',                                  dkim_header['i']
       assert_equal '2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8=',  dkim_header['bh']
-      assert_equal 'dCiulbJTD+GCCItMij1IU/RO0+q73afdjmrCWV5Qu7BIT5Kbp5Oi3jqCzj/v8Juks2/L6GBSXZia3aZprNVZX0szt8RnwC9NJx9WhcjN2RPz4Zf5F1jJivCN+PtaIWA3i3Ki/DR1q+RuNPgs7T1KKMo3Ih5uHubZIsMwRzbQBc0=', dkim_header['b']
+      assert_equal 'E+b3dktXUAexSXidTLU6CDLLHgdyWkED27uPqGgYpQadOYrc+JcbdWCqzA4oqrtz5rs0Cjxh6X7AxpjU2xHY2kURkDozNoNMnrilg3Pw2lfpPt6yjP34O8vjnWsiRQBqfeXZ7BDWstPjmXJcjCUnOg9bf1y03jFDuzwHKZSYYNg=', dkim_header['b']
     end
 
     def test_empty_body_hashes
@@ -96,4 +96,3 @@ Received: <C>
     end
   end
 end
-


### PR DESCRIPTION
Hi!

This is an attempt to fix #20.

I checked the unfinished work [mentioned here](https://github.com/jhawthorn/dkim/issues/20#issuecomment-211504234) to update the `DkimField`, but it seemed more straightforward to have the line-wrapping logic in `DkimHeader`, because this requires less changes for other classes to benefit from it.

I also updated some of the expected hashes in tests, because they were all valid for non-wrapped headers but needed to change for wrapped headers...

Let me know how that works for you.