### PR TITLE
Adding support for DKIM expiration tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # dkim Changelog
 
+## Unreleased
+
+### Added
+
+* Add support for DKIM expiration tag
+
 ## 1.0.0 (2013-01-15)
 * DKIM-Signature header is now prepended rather than appended
 * Headers are signed in the order they appear

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Limitations
 * No support for the older Yahoo! DomainKeys standard ([RFC 4870](http://tools.ietf.org/html/rfc4870)) *(none planned)*
 * No support for specifying DKIM identity `i=` *(planned)*
 * No support for body length `l=` *(planned)*
-* No support for signature expiration `x=` *(planned)*
 * No support for copied header fields `z=` *(not immediately planned)*
 
 Resources

--- a/lib/dkim/options.rb
+++ b/lib/dkim/options.rb
@@ -22,6 +22,12 @@ module Dkim
     define_option_method :time
 
     # @attribute [rw]
+    # Signature expiration.
+    # This corresponds to the x= tag in the dkim header.
+    # @return [Time,#to_i] A Time object or seconds since the epoch
+    define_option_method :expire
+
+    # @attribute [rw]
     # The signing algorithm for dkim. Valid values are 'rsa-sha1' and 'rsa-sha256' (default).
     # This corresponds to the a= tag in the dkim header.
     # @return [String] signing algorithm

--- a/lib/dkim/signed_mail.rb
+++ b/lib/dkim/signed_mail.rb
@@ -63,6 +63,7 @@ module Dkim
       dkim_header['q'] = 'dns/txt'
       dkim_header['s'] = selector
       dkim_header['t'] = (time || Time.now).to_i
+      dkim_header['x'] = expire.to_i if expire
 
       # Add body hash and blank signature
       dkim_header['bh']= digest_alg.digest(canonical_body)

--- a/test/dkim/signed_mail_test.rb
+++ b/test/dkim/signed_mail_test.rb
@@ -46,6 +46,19 @@ module Dkim
       assert_equal 't+dk4yxTI2ByZxxRzkwhZhM4WzTZjGWHiWnS2t4pg7oT7fAIlMrfihJ/CIvGmYqYv4lbq4LStHqHx9TmEgxrkjLevHtuqhxkN55xJ2vA2QzTzFi2fMDZ4fFqWy4QtvlLjBAhevG+LXpmjPYec1cyeMlHlPAthq5+RNi6NHErJiM=', dkim_header['b']
     end
 
+    def test_expire
+      options = {
+        :time => Time.at(1234567890),
+        :expire => Time.at(1234567990)
+      }
+      signed_mail = SignedMail.new(@mail, options)
+      dkim_header = signed_mail.dkim_header.list
+
+      assert_equal 1234567990,                                      dkim_header['x']
+      assert_equal '2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8=',  dkim_header['bh']
+      assert_equal 'dn2Y5rSXQNRBy904vwpvri6xcmlrwKDmDX4XtBgyABQw9jLTulgD/G61TeyqinwgaHiatQaYt4pnpzYQGMaCCg7MepkkpZAR4IggAnHo/qB4JRx5OYBslKCCwpeb70YOPdukVopEnaCoUfkCGJ5vvu3xXG1N+ajKWqYiZ0n4z+o=', dkim_header['b']
+    end
+
     def test_identity
       options = {
         :domain => 'example.org',


### PR DESCRIPTION
Add support for DKIM expiration, the "x=" tag. Can be useful to make life harder for spammers. Thanks for this gem.